### PR TITLE
Fix: Instead of showing properties namespace show in RootObject

### DIFF
--- a/JsonCSharpClassGeneratorLib/JsonClassGenerator.cs
+++ b/JsonCSharpClassGeneratorLib/JsonClassGenerator.cs
@@ -80,7 +80,7 @@ namespace Xamasoft.JsonClassGenerator
             Types = new List<JsonType>();
             Names.Add(MainClass);
             var rootType = new JsonType(this, examples[0]);
-            rootType.IsRoot = true;
+            rootType.IsRoot = false;
             rootType.AssignName(MainClass);
             GenerateClass(examples, rootType);
 

--- a/JsonUtils/Controllers/HomeController.cs
+++ b/JsonUtils/Controllers/HomeController.cs
@@ -73,8 +73,9 @@ namespace JsonUtils.Controllers
         {
             if (string.IsNullOrEmpty(model.ClassName))
             {
-                model.Error = true;
-                model.ErrorNo = 1;
+                //model.Error = true;
+                //model.ErrorNo = 1;
+                model.ClassName = "RootObject";
             }
             else if (string.IsNullOrEmpty(model.JSON))
             {
@@ -150,7 +151,7 @@ namespace JsonUtils.Controllers
             gen.CodeWriter = writer;
             gen.ExplicitDeserialization = false;
             if (nest)
-                gen.Namespace = "JSONUtils." + classname;
+                gen.Namespace = "JSONUtils";
             else
                 gen.Namespace = null;
 


### PR DESCRIPTION
When we check "Add Namespace"
Class name is appending to the Namespace but when it's displaying created object it's showing properties under Namespace instead of Class