### PR TITLE
Added the possibility to generate field type name if the class already created

### DIFF
--- a/JsonCSharpClassGeneratorLib/JsonClassGenerator.cs
+++ b/JsonCSharpClassGeneratorLib/JsonClassGenerator.cs
@@ -221,9 +221,9 @@ namespace Xamasoft.JsonClassGenerator
                         }
                     }
 
+                    fieldType.AssignName(CreateUniqueClassName(field.Key));
                     if (!classNames.Contains(field.Key))
                     {
-                        fieldType.AssignName(CreateUniqueClassName(field.Key));
                         GenerateClass(subexamples.ToArray(), fieldType);
 
                         classNames.Add(field.Key);


### PR DESCRIPTION
This pull request solve issue #27 and #6  

A sample json for test:

```javascript
{
    "books": [
        {
            "id": 1,
            "name": "Book 1",
            "number_of_pages": 300,
            "author": {
                "id": 1,
                "name": "Author 1"
            }
        }
    ],
    "audio_books": [
        {
            "id": 1,
            "name": "Audio Book 1", 
            "length": 1200,
            "author": {
                "id": 1,
                "name": "Author 1"
            }
        }
    ]
}
```

I thing it's necessary implement a fields verification of the class to decide use the same class type or generate new, but I believe that this is a great start.