### PR TITLE
Added namespace support in PHP code generation

### DIFF
--- a/JsonCSharpClassGeneratorLib/CodeWriters/PhpCodeWriter.cs
+++ b/JsonCSharpClassGeneratorLib/CodeWriters/PhpCodeWriter.cs
@@ -76,7 +76,7 @@ namespace Xamasoft.JsonClassGenerator.CodeWriters
             sw.WriteLine("{");
             //}
 
-            var prefix = config.UseNestedClasses && !type.IsRoot ? "" : "    ";
+            var prefix = "    ";
 
 
             var shouldSuppressWarning = config.InternalVisibility && !config.UseProperties && !config.ExplicitDeserialization;
@@ -105,12 +105,7 @@ namespace Xamasoft.JsonClassGenerator.CodeWriters
                 sw.WriteLine();
             }
 
-
-            if (config.UseNestedClasses && !type.IsRoot)
-                sw.WriteLine("        }");
-
-            if (!config.UseNestedClasses)
-                sw.WriteLine("}");
+            sw.WriteLine("}");
 
             sw.WriteLine();
         }
@@ -128,6 +123,9 @@ namespace Xamasoft.JsonClassGenerator.CodeWriters
         public void WriteNamespaceStart(IJsonClassGeneratorConfig config, TextWriter sw, bool root)
         {
             sw.WriteLine("<?php");
+            sw.Write("\r");
+            sw.Write("namespace {0};", config.Namespace);
+            sw.Write("\r");
             sw.Write("\r");
         }
 

--- a/JsonUtils/Views/Home/Index.cshtml
+++ b/JsonUtils/Views/Home/Index.cshtml
@@ -276,8 +276,6 @@
                 $("#div-properties").show();
                 break;
             case 6: //PHP
-                $('#Nest').attr('disabled', 'disabled');
-                $('#Namespace').attr('disabled', 'disabled');
                 $('#Pascal').attr('disabled', 'disabled');
                 $('#PropertyAttribute').attr('disabled', 'disabled');
                 $("#div-properties").show();


### PR DESCRIPTION
PHP classes can support namespaces.

An example of PHP class with namespace:

```php
<?php

namespace Name\Of\Namespace;

class Foo
{
}
```